### PR TITLE
Helm test fix: linkerd.io/inject disabled

### DIFF
--- a/cluster/charts/podinfo/templates/tests/jwt.yaml
+++ b/cluster/charts/podinfo/templates/tests/jwt.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
+    linkerd.io/inject: disabled
     "helm.sh/hook": test-success
 spec:
   containers:

--- a/cluster/charts/podinfo/templates/tests/service.yaml
+++ b/cluster/charts/podinfo/templates/tests/service.yaml
@@ -8,6 +8,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
+    linkerd.io/inject: disabled
     "helm.sh/hook": test-success
 spec:
   containers:

--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -21,6 +21,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app: {{ template "podinfo.name" . }}
   annotations:
+    linkerd.io/inject: disabled
     "helm.sh/hook": test-success
 spec:
   containers:
@@ -109,7 +110,7 @@ spec:
           type: "helm"
           cmd: "test podinfo --cleanup"
       - name: load-test
-        url: http://tester.prod/
+        url: http://load-tester.prod/
         metadata:
           cmd: "hey -z 2m -q 10 -c 2 http://podinfo:9898/"
 ```


### PR DESCRIPTION
Disabling linkerd injection here lets the helm tests reach podinfo canary, so they can pass