### PR TITLE
Update workshop to Helm v3 

### DIFF
--- a/cluster/releases/helm-tester.yaml
+++ b/cluster/releases/helm-tester.yaml
@@ -4,7 +4,7 @@ metadata:
   name: helm-tester
   namespace: prod
   annotations:
-    fluxcd.io/ignore: "false"
+    fluxcd.io/ignore: "true"
 spec:
   releaseName: helm-tester
   chart:

--- a/cluster/releases/nginx-ingress.yaml
+++ b/cluster/releases/nginx-ingress.yaml
@@ -10,8 +10,15 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: nginx-ingress
-    version: 1.16.0
+    version: 1.19.0
   values:
     controller:
       service:
         type: LoadBalancer
+      metrics:
+        enabled: true
+      podAnnotations:
+        prometheus.io/port: 10254
+        prometheus.io/scrape: true
+      stats:
+        enabled: true

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -9,6 +9,7 @@ metadata:
     fluxcd.io/tag.chart-image: semver:~3.0
 spec:
   releaseName: podinfo
+  helmVersion: v3
   chart:
     git: git@github.com:stefanprodan/gitops-helm-workshop
     ref: test

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
@@ -17,7 +18,7 @@ spec:
   values:
     image:
       repository: stefanprodan/podinfo
-      tag: 3.0.0
+      tag: 3.0.5
     service:
       enabled: true
       type: ClusterIP
@@ -31,4 +32,4 @@ spec:
           proxy_hide_header l5d-server-id;
       path: /
       hosts:
-        - 35.198.97.122.nip.io
+      - 35.198.97.122.nip.io

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -4,14 +4,14 @@ metadata:
   name: podinfo
   namespace: prod
   annotations:
-    fluxcd.io/ignore: "true"
+    fluxcd.io/ignore: "false"
     fluxcd.io/automated: "false"
     fluxcd.io/tag.chart-image: semver:~3.0
 spec:
   releaseName: podinfo
   chart:
     git: git@github.com:stefanprodan/gitops-helm-workshop
-    ref: master
+    ref: test
     path: cluster/charts/podinfo
   values:
     image:

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -22,7 +22,7 @@ spec:
       enabled: true
       type: ClusterIP
     ingress:
-      enabled: false
+      enabled: true
       annotations:
         kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/configuration-snippet: |

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -29,6 +29,6 @@ spec:
           proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:9898;
           proxy_hide_header l5d-remote-ip;
           proxy_hide_header l5d-server-id;
-      path: /*
+      path: /
       hosts:
-        - podinfo.local
+        - 35.198.97.122.nip.io

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -5,12 +5,11 @@ metadata:
   name: podinfo
   namespace: prod
   annotations:
-    fluxcd.io/ignore: "false"
-    fluxcd.io/automated: "true"
+    fluxcd.io/ignore: "true"
+    fluxcd.io/automated: "false"
     fluxcd.io/tag.chart-image: semver:~3.0
 spec:
   releaseName: podinfo
-  helmVersion: v3
   chart:
     git: git@github.com:stefanprodan/gitops-helm-workshop
     ref: test
@@ -18,7 +17,7 @@ spec:
   values:
     image:
       repository: stefanprodan/podinfo
-      tag: 3.0.5
+      tag: 3.0.0
     service:
       enabled: true
       type: ClusterIP

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     fluxcd.io/ignore: "true"
     fluxcd.io/automated: "false"
-    fluxcd.io/tag.chart-image: semver:~2.1
+    fluxcd.io/tag.chart-image: semver:~3.0
 spec:
   releaseName: podinfo
   chart:
@@ -16,18 +16,16 @@ spec:
   values:
     image:
       repository: stefanprodan/podinfo
-      tag: 2.1.0
+      tag: 3.0.0
     service:
       enabled: true
       type: ClusterIP
     ingress:
-      enabled: true
+      enabled: false
       annotations:
         kubernetes.io/ingress.class: "nginx"
         nginx.ingress.kubernetes.io/configuration-snippet: |
           proxy_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:9898;
           proxy_hide_header l5d-remote-ip;
           proxy_hide_header l5d-server-id;
-      path: /
-      hosts:
-        - *
+      path: /*

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prod
   annotations:
     fluxcd.io/ignore: "false"
-    fluxcd.io/automated: "false"
+    fluxcd.io/automated: "true"
     fluxcd.io/tag.chart-image: semver:~3.0
 spec:
   releaseName: podinfo

--- a/cluster/releases/podinfo.yaml
+++ b/cluster/releases/podinfo.yaml
@@ -30,3 +30,5 @@ spec:
           proxy_hide_header l5d-remote-ip;
           proxy_hide_header l5d-server-id;
       path: /*
+      hosts:
+        - podinfo.local

--- a/cluster/releases/sealed-secrets.yaml
+++ b/cluster/releases/sealed-secrets.yaml
@@ -10,4 +10,4 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com/
     name: sealed-secrets
-    version: 1.3.4
+    version: 1.4.0

--- a/docs/canary/README.md
+++ b/docs/canary/README.md
@@ -40,12 +40,14 @@ fluxctl sync
 
 Create a canary release for podinfo:
 
-```yaml
+```yaml{7}
 apiVersion: flagger.app/v1alpha3
 kind: Canary
 metadata:
   name: podinfo
   namespace: prod
+  annotations:
+    fluxcd.io/ignore: "false"
 spec:
   targetRef:
     apiVersion: apps/v1
@@ -90,7 +92,7 @@ kubectl -n prod get canary
 
 Install the load testing service to generate traffic during the canary analysis:
 
-```yaml
+```yaml{7}
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:


### PR DESCRIPTION
- add Helm v3 CLI install steps
- use Flux Helm Operator helm-v3 pre release
- update all commands to work with Helm v3

TODO: Updated Flagger helm testing to v3