### PR TITLE
account for (helm3?) bug

### DIFF
--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -90,7 +90,7 @@ spec:
         timeout: 2m
         metadata:
           type: "helmv3"
-          cmd: "test run podinfo --cleanup -n prod"
+          cmd: "test run podinfo --cleanup"
       - name: load-test
         url: http://load-tester.prod/
         metadata:


### PR DESCRIPTION
running the tests with a namespace specified does not use the default service account