### PR TITLE
Update apiVersion to linkerd.io/v1alpha1

### DIFF
--- a/cluster/charts/podinfo/templates/profile.yaml
+++ b/cluster/charts/podinfo/templates/profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: linkerd.io/v1alpha2
+apiVersion: linkerd.io/v1alpha1
 kind: ServiceProfile
 metadata:
     name: "{{ template "podinfo.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"


### PR DESCRIPTION
With Linkerd 2.4 apiVersion: linkerd.io/v1alpha2 does not work. Change to apiVersion: linkerd.io/v1alpha1 works.